### PR TITLE
Check sundering talent for priority rotation

### DIFF
--- a/Specialization/Enhancement.lua
+++ b/Specialization/Enhancement.lua
@@ -523,7 +523,7 @@ function Shaman:EnhancementPriority()
 	end
 
 	-- sundering,if=active_enemies>=3;
-	if cooldown[EH.Sundering].ready and maelstrom >= 20 and targets >= 3 then
+	if talents[EH.Sundering] and cooldown[EH.Sundering].ready and maelstrom >= 20 and targets >= 3 then
 		return EH.Sundering;
 	end
 


### PR DESCRIPTION
Added check for Sundering talent to "priority" rotation due to chat spam from levels 1-90.