### PR TITLE
Fix GetSpellCost

### DIFF
--- a/Specialization/Elemental.lua
+++ b/Specialization/Elemental.lua
@@ -38,10 +38,10 @@ local EL = {
 
 setmetatable(EL, Shaman.spellMeta);
 
-local function getSpellCost(spellId, defaultCost)
+local function getSpellCost(spellId, defaultCost, resource)
 	local cost = GetSpellPowerCost(spellId);
-	if cost ~= nil then
-		return cost[1].cost;
+	if cost and resource and cost[resource] and cost[resource].cost then
+	    return cost[resource].cost;
 	end
 
 	return defaultCost
@@ -58,15 +58,15 @@ function Shaman:Elemental()
 	local maelstrom = UnitPower('player', Maelstrom);
 
 	if talents[EL.EarthShock] then
-		fd.earthShockCost = getSpellCost(EL.EarthShock, 60)
+		fd.earthShockCost = getSpellCost(EL.EarthShock, 60, 2)
 	end
 
 	if talents[EL.ElementalBlast] then
-		fd.elementalBlastCost = getSpellCost(EL.ElementalBlast, 90)
+		fd.elementalBlastCost = getSpellCost(EL.ElementalBlast, 90, 2)
 	end
 
 	if talents[EL.Earthquake] then
-		fd.earthQuakeCost = getSpellCost(EL.Earthquake, 60)
+		fd.earthQuakeCost = getSpellCost(EL.Earthquake, 60, 2)
 	end
 
 	local currentSpell = fd.currentSpell


### PR DESCRIPTION
In the case where there is another resource then mana, the table returned by GetSpellPowerCost will have more then 1 index. For the spells that do not cost mana we want to the value from the second index. As far as I can tell at least for shaman there is only 2 resources and no spell costs more then one so is either index 1 or 2.